### PR TITLE
Add code to generate validator ed25519 address used in genesis config

### DIFF
--- a/evm-consensus/src/evm/committee.rs
+++ b/evm-consensus/src/evm/committee.rs
@@ -1,18 +1,14 @@
 use crate::{
     authority_keypair_from_private_key, network_keypair_from_private_key,
     protocol_keypair_from_private_key,
-    validator::{AuthorityConfig, ValidatorConfigs},
+    validator::{AuthorityConfig, ValidatorConfigs, generate_validator_sui_address},
 };
 use anyhow::Result;
 use consensus_config::{
     Authority, AuthorityKeyPair, AuthorityPublicKey, Committee, NetworkKeyPair, NetworkPublicKey,
     ProtocolKeyPair, ProtocolPublicKey,
 };
-use fastcrypto::{
-    bls12381, ed25519,
-    hash::{Blake2b256, HashFunction},
-    traits::ToFromBytes as _,
-};
+use fastcrypto::{bls12381, ed25519, traits::ToFromBytes as _};
 use rand::{SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -156,6 +152,7 @@ fn generate_committee_from_validator_configs(
             authority_key: hex::encode(authority_keypair.public().to_bytes()),
             protocol_key: hex::encode(protocol_keypair.public().to_bytes()),
             network_key: hex::encode(network_keypair.public().to_bytes()),
+            validator_address: generate_validator_sui_address(&network_keypair.public()),
         });
     }
 
@@ -476,42 +473,17 @@ pub fn generate_genesis_config(config_path: &Path, genesis_path: &Path) -> Resul
     Ok(())
 }
 
-/// Generates a Sui-style address from a network public key
-///
-/// This follows Sui's address generation algorithm:
-/// 1. Create a Blake2b256 hasher
-/// 2. Hash the signature scheme flag byte (0x00 for Ed25519)
-/// 3. Hash the public key bytes
-/// 4. Take the first 32 bytes of the digest as the address
-///
-/// Returns the address as a hex string (64 hex characters, no 0x prefix)
-pub fn generate_validator_sui_address(network_pub_key: &NetworkPublicKey) -> String {
-    // Ed25519 signature scheme flag (as per Sui's SignatureScheme::flag())
-    const ED25519_SCHEME_FLAG: u8 = 0x00;
-
-    // Create Blake2b256 hasher (Sui uses Blake2b256, not Keccak256)
-    let mut hasher = Blake2b256::new();
-
-    // Hash the signature scheme flag
-    hasher.update([ED25519_SCHEME_FLAG]);
-
-    // Hash the public key bytes
-    hasher.update(network_pub_key.to_bytes());
-
-    // Get the digest (32 bytes)
-    let address_bytes: [u8; 32] = hasher.finalize().into();
-
-    // Return as hex string (no 0x prefix, 64 hex characters)
-    hex::encode(address_bytes)
-}
 #[cfg(test)]
 mod tests {
     use super::{
         AuthorityConfig, CommitteeConfig, GenesisConfig, extract_peer_addresses,
-        generate_committees, generate_genesis_config, generate_validator_sui_address, is_valid_ip,
-        is_valid_port, load_committees, parse_ip_port_from_address,
+        generate_committees, generate_genesis_config, is_valid_ip, is_valid_port, load_committees,
+        parse_ip_port_from_address,
     };
-    use crate::{ValidatorConfig, ValidatorConfigs, generate_validators};
+    use crate::{
+        ValidatorConfig, ValidatorConfigs, generate_validators,
+        validator::generate_validator_sui_address,
+    };
     use consensus_config::{
         Authority, AuthorityKeyPair, Committee, NetworkKeyPair, ProtocolKeyPair, Stake,
     };
@@ -731,6 +703,7 @@ mod tests {
                 authority_key: "key1".to_string(),
                 protocol_key: "key2".to_string(),
                 network_key: "key3".to_string(),
+                validator_address: "1234567890".to_string(),
             }],
             quorum_threshold: 1,
             validity_threshold: 1,

--- a/evm-consensus/src/evm/converter.rs
+++ b/evm-consensus/src/evm/converter.rs
@@ -6,7 +6,7 @@ use rpc_shared_api::{
     Transaction, VerifiedBlock,
 };
 
-use crate::evm::committee::generate_validator_sui_address;
+use crate::validator::generate_validator_sui_address;
 
 pub fn create_evm_committed_subdag(
     subdag: CommittedSubDag,

--- a/evm-consensus/src/main.rs
+++ b/evm-consensus/src/main.rs
@@ -562,7 +562,7 @@ validity_threshold: 1
 
         // This test verifies that the function can be called without panicking
         // The actual result may vary depending on the consensus client setup
-        let result = start_consensus_client(&config_path).await;
+        let _result = start_consensus_client(&config_path).await;
 
         // Test passes if we can call the function without panicking
         // The actual result may be an error due to missing dependencies
@@ -582,7 +582,7 @@ missing_required_fields: true
         fs::write(&invalid_config_path, invalid_content).unwrap();
 
         // This should handle invalid config gracefully
-        let result = start_consensus_client(&invalid_config_path).await;
+        let _result = start_consensus_client(&invalid_config_path).await;
 
         // Test passes if we can handle invalid input without panicking
         assert!(true);
@@ -610,7 +610,7 @@ log_level: info
         fs::write(&config_path, config_content).unwrap();
 
         // This should handle missing committee file gracefully
-        let result = start_consensus_client(&config_path).await;
+        let _result = start_consensus_client(&config_path).await;
 
         // Test passes if we can handle missing files without panicking
         assert!(true);
@@ -669,53 +669,6 @@ log_level: info
             let result: Vec<String> = input.split(',').map(|s| s.trim().to_string()).collect();
             assert_eq!(result, expected);
         }
-    }
-
-    #[test]
-    fn test_registry_service_creation() {
-        let registry = Registry::new();
-        let registry_service = RegistryService::new(registry);
-
-        // Test that we can create the registry service
-        assert!(true);
-    }
-
-    #[test]
-    fn test_validator_node_creation() {
-        let working_directory = PathBuf::from("/tmp/test");
-        let validator = ValidatorNode::new(0, working_directory);
-
-        // Test that we can create the validator node
-        assert!(true);
-    }
-
-    #[test]
-    fn test_path_operations() {
-        let base_path = PathBuf::from("/tmp");
-        let sub_path = base_path.join("test");
-        let final_path = sub_path.join("config.yml");
-
-        assert_eq!(final_path, PathBuf::from("/tmp/test/config.yml"));
-        assert!(final_path.to_string_lossy().contains("config.yml"));
-    }
-
-    #[test]
-    fn test_string_operations() {
-        let test_string = "test_value";
-        let trimmed = test_string.trim();
-        let parsed: u16 = "8080".parse().unwrap();
-
-        assert_eq!(trimmed, "test_value");
-        assert_eq!(parsed, 8080);
-    }
-
-    #[test]
-    fn test_error_handling() {
-        // Test that we can create anyhow errors
-        let error = anyhow::anyhow!("Test error message");
-        let error_string = error.to_string();
-
-        assert!(error_string.contains("Test error message"));
     }
 
     #[test]

--- a/evm-consensus/src/validator/config.rs
+++ b/evm-consensus/src/validator/config.rs
@@ -75,6 +75,9 @@ pub struct AuthorityConfig {
     pub authority_key: String,
     pub protocol_key: String,
     pub network_key: String,
+    /// ed25519 format generated from network public key
+    /// This value is used to generate genesis.json for execution layer
+    pub validator_address: String,
 }
 
 #[cfg(test)]

--- a/evm-consensus/src/validator/mod.rs
+++ b/evm-consensus/src/validator/mod.rs
@@ -1,14 +1,48 @@
 mod config;
 use anyhow::Result;
 pub use config::{AuthorityConfig, ValidatorConfig, ValidatorConfigs};
-use consensus_config::{AuthorityKeyPair, NetworkKeyPair, ProtocolKeyPair};
-use fastcrypto::{bls12381, ed25519, traits::KeyPair as _};
+use consensus_config::{AuthorityKeyPair, NetworkKeyPair, NetworkPublicKey, ProtocolKeyPair};
+use fastcrypto::{
+    bls12381, ed25519,
+    hash::{Blake2b256, HashFunction},
+    traits::KeyPair as _,
+};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use serde_yaml;
 use std::fs;
 use std::path::Path;
 use tracing::info;
+
+/// Generates a Sui-style address from a network public key
+///
+/// This follows Sui's address generation algorithm:
+/// 1. Create a Blake2b256 hasher
+/// 2. Hash the signature scheme flag byte (0x00 for Ed25519)
+/// 3. Hash the public key bytes
+/// 4. Take the first 32 bytes of the digest as the address
+///
+/// Returns the address as a hex string (64 hex characters, no 0x prefix)
+pub fn generate_validator_sui_address(network_pub_key: &NetworkPublicKey) -> String {
+    // Ed25519 signature scheme flag (as per Sui's SignatureScheme::flag())
+    const ED25519_SCHEME_FLAG: u8 = 0x00;
+
+    // Create Blake2b256 hasher (Sui uses Blake2b256, not Keccak256)
+    let mut hasher = Blake2b256::new();
+
+    // Hash the signature scheme flag
+    hasher.update([ED25519_SCHEME_FLAG]);
+
+    // Hash the public key bytes
+    hasher.update(network_pub_key.to_bytes());
+
+    // Get the digest (32 bytes)
+    let address_bytes: [u8; 32] = hasher.finalize().into();
+
+    // Return as hex string (no 0x prefix, 64 hex characters)
+    hex::encode(address_bytes)
+}
+
 /// Generates validator configurations and saves them to a YAML file
 ///
 /// This function generates validator configurations based on the provided parameters
@@ -84,6 +118,7 @@ pub fn generate_validator(
         authority_key: hex::encode(authority_keypair.public().to_bytes()),
         protocol_key: hex::encode(protocol_keypair.public().to_bytes()),
         network_key: network_public_key_hex,
+        validator_address: generate_validator_sui_address(&network_keypair.public()),
     };
     let authority_yaml = serde_yaml::to_string(&authority)?;
     fs::write(authority_path, authority_yaml)?;


### PR DESCRIPTION
Extract more data for genesis generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized validator address generation logic across modules for improved code structure.
  * Extended authority configuration to include validator_address field for validator setup.
  * Updated configuration handling to properly initialize new validator address fields.

* **Tests**
  * Removed multiple unit tests from main module to reduce test redundancy.
  * Updated remaining tests to reflect configuration changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->